### PR TITLE
Inventory-related overrides

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -336,7 +336,12 @@
         </service>
         <service id="sylius.listener.order_inventory" class="%sylius.listener.order_inventory.class%">
             <argument type="service" id="sylius.order_processing.inventory_handler" />
-            <tag name="kernel.event_listener" event="sylius.checkout.finalize.pre_complete" method="holdInventoryUnits" />
+            <!--
+                I could use a CompilerPass but I think it's clearer to see if I just change our fork.
+                We don't want to holdInventory at this time, it's not part of our business logic.
+                We hold units at the end of the process
+            -->
+            <!--<tag name="kernel.event_listener" event="sylius.checkout.finalize.pre_complete" method="holdInventoryUnits" />-->
             <tag name="kernel.event_listener" event="sylius.order_item.pre_create" method="resolveInventoryState" priority="-100" />
             <tag name="kernel.event_listener" event="sylius.order_item.pre_update" method="resolveInventoryState" priority="-100" />
         </service>

--- a/src/Sylius/Component/Core/OrderProcessing/InventoryHandler.php
+++ b/src/Sylius/Component/Core/OrderProcessing/InventoryHandler.php
@@ -98,7 +98,7 @@ class InventoryHandler implements InventoryHandlerInterface
             }
 
             $this->inventoryOperator->release($item->getVariant(), $quantity);
-            $this->inventoryOperator->decrease($units);
+            $this->inventoryOperator->decrease($item->getVariant(), $quantity);
         }
     }
 

--- a/src/Sylius/Component/Core/spec/OrderProcessing/InventoryHandlerSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/InventoryHandlerSpec.php
@@ -136,7 +136,7 @@ class InventoryHandlerSpec extends ObjectBehavior
         $sm2->can(InventoryUnitTransitions::SYLIUS_RELEASE)->willReturn(false);
         $sm2->apply(InventoryUnitTransitions::SYLIUS_SELL)->shouldBeCalled();
 
-        $inventoryOperator->decrease([$unit1, $unit2])->shouldBeCalled();
+        $inventoryOperator->decrease($variant, 1)->shouldBeCalled();
         $inventoryOperator->release($variant, 1)->shouldBeCalled();
 
         $this->updateInventory($order);

--- a/src/Sylius/Component/Inventory/Operator/InventoryOperatorInterface.php
+++ b/src/Sylius/Component/Inventory/Operator/InventoryOperatorInterface.php
@@ -48,9 +48,12 @@ interface InventoryOperatorInterface
     public function release(StockableInterface $stockable, $quantity);
 
     /**
+     * NOTE: Overridden from base Sylius because there's is wrong, it's doing too much in this context
+     *
      * Decrease stock by count of given inventory units.
      *
-     * @param StockableInterface[]|Collection $inventoryUnits
+     * @param StockableInterface $stockable
+     * @param int            $quantity
      */
-    public function decrease($inventoryUnits);
+    public function decrease(StockableInterface $stockable, $quantity);
 }

--- a/src/Sylius/Component/Inventory/Operator/NoopInventoryOperator.php
+++ b/src/Sylius/Component/Inventory/Operator/NoopInventoryOperator.php
@@ -31,7 +31,7 @@ class NoopInventoryOperator implements InventoryOperatorInterface
     /**
      * {@inheritdoc}
      */
-    public function decrease($inventoryUnits)
+    public function decrease(StockableInterface $stockable, $quantity)
     {
         // nothing happens.
     }

--- a/src/Sylius/Component/Inventory/spec/Operator/InventoryOperatorSpec.php
+++ b/src/Sylius/Component/Inventory/spec/Operator/InventoryOperatorSpec.php
@@ -51,50 +51,11 @@ class InventoryOperatorSpec extends ObjectBehavior
         $this->increase($stockable, 5);
     }
 
-    function it_decreases_stockable_on_hand_by_count_of_sold_units(
-        $availabilityChecker,
-        $backordersHandler,
-        StockableInterface $stockable,
-        InventoryUnitInterface $inventoryUnit1,
-        InventoryUnitInterface $inventoryUnit2
-    ) {
-        $inventoryUnit1->getStockable()->willReturn($stockable);
-        $inventoryUnit2->getStockable()->willReturn($stockable);
+    function it_decreases_stockable_on_hand(StockableInterface $stockable)
+    {
+        $stockable->getOnHand()->shouldBeCalled()->willReturn(5);
+        $stockable->setOnHand(2)->shouldBeCalled();
 
-        $availabilityChecker->isStockSufficient($stockable, 2)->shouldBeCalled()->willReturn(true);
-        $backordersHandler->processBackorders([$inventoryUnit1, $inventoryUnit2])->shouldBeCalled();
-
-        $inventoryUnit1->getInventoryState()->shouldBeCalled()->willReturn(InventoryUnitInterface::STATE_SOLD);
-        $inventoryUnit2->getInventoryState()->shouldBeCalled()->willReturn(InventoryUnitInterface::STATE_SOLD);
-
-        $stockable->getOnHand()->shouldBeCalled()->willReturn(7);
-        $stockable->setOnHand(5)->shouldBeCalled();
-
-        $this->decrease([$inventoryUnit1, $inventoryUnit2]);
-    }
-
-    function it_decreases_stockable_on_hand_and_ignores_backordered_units(
-        $availabilityChecker,
-        $backordersHandler,
-        StockableInterface $stockable,
-        InventoryUnitInterface $inventoryUnit1,
-        InventoryUnitInterface $inventoryUnit2,
-        InventoryUnitInterface $inventoryUnit3
-    ) {
-        $inventoryUnit1->getStockable()->willReturn($stockable);
-        $inventoryUnit2->getStockable()->willReturn($stockable);
-        $inventoryUnit3->getStockable()->willReturn($stockable);
-
-        $availabilityChecker->isStockSufficient($stockable, 3)->shouldBeCalled()->willReturn(true);
-        $backordersHandler->processBackorders([$inventoryUnit1, $inventoryUnit2, $inventoryUnit3])->shouldBeCalled();
-
-        $inventoryUnit1->getInventoryState()->shouldBeCalled()->willReturn(InventoryUnitInterface::STATE_SOLD);
-        $inventoryUnit2->getInventoryState()->shouldBeCalled()->willReturn(InventoryUnitInterface::STATE_BACKORDERED);
-        $inventoryUnit3->getInventoryState()->shouldBeCalled()->willReturn(InventoryUnitInterface::STATE_BACKORDERED);
-
-        $stockable->getOnHand()->shouldBeCalled()->willReturn(1);
-        $stockable->setOnHand(0)->shouldBeCalled();
-
-        $this->decrease([$inventoryUnit1, $inventoryUnit2, $inventoryUnit3]);
+        $this->decrease($stockable, 3);
     }
 }


### PR DESCRIPTION
### Don't try to hold stock at `finalise.pre_complete` stage:
- We don't want this. It's some Sylius thing about holding stock temporarily before you pay.
- We hold stock after payment authorisation in a different process.
- It felt cleaner to modify our fork rather than relying on a CompilerPass because the Sylius checkout events are already very complicated and following them is painful enough without remembering there's a compiler pass removing listeners...
### Remove this bad implementation of InventoryOperator->decrease()
- There are clean and obvious methods for `increase()`, `hold()` and `release()` following a consistent decoupled pattern.
- Then `decrease()` does a whole load of crazy shit around back orders and state transitions that it really shouldn't have any knowledge of.
- It also is based on an interface with a completely different signature from something I want to use.
- So I've rewritten it here on the fork so it's cleaner.
