### PR TITLE
Deregister event subscriber sylius.listener.cart

### DIFF
--- a/src/Sylius/Bundle/CartBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CartBundle/Resources/config/services.xml
@@ -39,6 +39,8 @@
             <argument type="service" id="event_dispatcher" />
         </service>
 
+	<!-- We extend this subscriber class and register it with our own dependencies.
+
         <service id="sylius.listener.cart" class="%sylius.listener.cart.class%">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="sylius.manager.cart" />
@@ -46,6 +48,7 @@
             <argument type="service" id="sylius.cart_provider" />
             <argument type="service" id="sylius.order_item_quantity_modifier" />
         </service>
+        -->
 
         <service id="sylius.listener.cart_flash" class="%sylius.listener.cart_flash.class%">
             <tag name="kernel.event_subscriber" />


### PR DESCRIPTION
We will have to merge this one about the same time as the Reiss PR or just after it is merged.

https://github.com/ReissClothing/reiss/pull/2362

edit. actually the Composer lock can be updated in that PR, nvm
