### PR TITLE
RS-2002 City field is nullable.

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/doctrine/model/Address.orm.xml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/doctrine/model/Address.orm.xml
@@ -35,7 +35,7 @@
         <field name="company" column="company" type="string" nullable="true">
             <gedmo:versioned />
         </field>
-        <field name="city" column="city" type="string">
+        <field name="city" column="city" type="string" nullable="true">
             <gedmo:versioned />
         </field>
         <field name="postcode" column="postcode" type="string" nullable="true">


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | RS-220


This will prevent fatal errors during checkout when PayPal addresses
do not have cities.
