### PR TITLE
Edge case bugs - Address without Customer, CartItem form without CartItem

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/Form/DataMapper/OrderItemQuantityDataMapper.php
+++ b/src/Sylius/Bundle/OrderBundle/Form/DataMapper/OrderItemQuantityDataMapper.php
@@ -52,6 +52,12 @@ class OrderItemQuantityDataMapper implements DataMapperInterface
      */
     public function mapFormsToData($forms, &$data)
     {
+        if (empty($data)) {
+            // Avoid a fatal error on trying to map data to null below.
+            // Not 100% sure why/how this happens so will see what this change does... PW 12/2016
+            return;
+        }
+
         $formsOtherThanQuantity = [];
         foreach ($forms as $key => $form) {
             if ('quantity' === $form->getName()) {

--- a/src/Sylius/Bundle/WebBundle/Controller/Frontend/Account/AddressController.php
+++ b/src/Sylius/Bundle/WebBundle/Controller/Frontend/Account/AddressController.php
@@ -223,11 +223,12 @@ class AddressController extends FOSRestController
      */
     protected function findUserAddressOr404($id)
     {
+        /** @var AddressInterface $address */
         if (!$address = $this->getAddressRepository()->find($id)) {
             throw new NotFoundHttpException('Requested address does not exist.');
         }
 
-        if (!$this->getCustomer()->hasAddress($address)) {
+        if (!$this->getCustomer() || !$this->getCustomer()->hasAddress($address)) {
             throw new AccessDeniedException();
         }
 


### PR DESCRIPTION
Attempt to fix a couple of email alerts.

Looks like a CartItem form submitted where the backend for the CartItem has also gone (could be follow-up to this issue after attempting to resolve the DataMapper fatal:

```
Uncaught PHP Exception Symfony\Component\PropertyAccess\Exception\InvalidArgumentException: "Expected argument of type "lius\Component\Core\Model\OrderItem::setVariant() must implement interface Sylius\Component\Core\Model\ProductVariantInterface", "NULL" given" at /app/reiss_prod/vendor/symfony/symfony/src/Symfony/Component/PropertyAccess/PropertyAccessor.php line 254
{
    "class": "Symfony\\Component\\PropertyAccess\\Exception\\InvalidArgumentException",
    "message": "Expected argument of type \"lius\\Component\\Core\\Model\\OrderItem::setVariant() must implement interface Sylius\\Component\\Core\\Model\\ProductVariantInterface\", \"NULL\" given",
    "code": 0,
    "file": "/app/reiss_prod/vendor/symfony/symfony/src/Symfony/Component/PropertyAccess/PropertyAccessor.php:254",
    "trace": [
        "/app/reiss_prod/vendor/symfony/symfony/src/Symfony/Component/PropertyAccess/PropertyAccessor.php:218",
        "/app/reiss_prod/vendor/symfony/symfony/src/Symfony/Component/Form/Extension/Core/DataMapper/PropertyPathMapper.php:93",
        "/app/reiss_prod/vendor/sylius/sylius/src/Sylius/Bundle/OrderBundle/Form/DataMapper/OrderItemQuantityDataMapper.php:68",
        "/app/reiss_prod/vendor/symfony/symfony/src/Symfony/Component/Form/Form.php:623",
        "/app/reiss_prod/vendor/symfony/symfony/src/Symfony/Component/Form/Form.php:567",
        "/app/reiss_prod/vendor/symfony/symfony/src/Symfony/Component/Form/Form.php:567",
        "/app/reiss_prod/vendor/symfony/symfony/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php:116",
        "/app/reiss_prod/vendor/symfony/symfony/src/Symfony/Component/Form/Form.php:489",
        "/app/reiss_prod/src/Reiss/Bundle/StoreBundle/Controller/CartController.php:104",
    ]
}
```

Adding an address without a Customer:

```
Uncaught PHP Exception Symfony\Component\Debug\Exception\FatalThrowableError: "Call to a member function hasAddress() on null" at /app/reiss_prod/vendor/sylius/sylius/src/Sylius/Bundle/WebBundle/Controller/Frontend/Account/AddressController.php line 230
{
    "class": "Symfony\\Component\\Debug\\Exception\\FatalThrowableError",
    "message": "Call to a member function hasAddress() on null",
    "code": 0,
    "file": "/app/reiss_prod/vendor/sylius/sylius/src/Sylius/Bundle/WebBundle/Controller/Frontend/Account/AddressController.php:230",
    "trace": [
        "/app/reiss_prod/vendor/sylius/sylius/src/Sylius/Bundle/WebBundle/Controller/Frontend/Account/AddressController.php:121",
}
```
