### PR TITLE
Fix setVariant null error

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/Form/DataMapper/OrderItemQuantityDataMapper.php
+++ b/src/Sylius/Bundle/OrderBundle/Form/DataMapper/OrderItemQuantityDataMapper.php
@@ -31,12 +31,12 @@ class OrderItemQuantityDataMapper implements DataMapperInterface
 
     /**
      * @param OrderItemQuantityModifierInterface $orderItemQuantityModifier
-     * @param DataMapperInterface $propertyPathDataMapper
+     * @param DataMapperInterface                $propertyPathDataMapper
      */
     public function __construct(OrderItemQuantityModifierInterface $orderItemQuantityModifier, DataMapperInterface $propertyPathDataMapper)
     {
         $this->orderItemQuantityModifier = $orderItemQuantityModifier;
-        $this->propertyPathDataMapper = $propertyPathDataMapper;
+        $this->propertyPathDataMapper    = $propertyPathDataMapper;
     }
 
     /**
@@ -60,8 +60,7 @@ class OrderItemQuantityDataMapper implements DataMapperInterface
 
         $formsOtherThanQuantity = [];
         foreach ($forms as $key => $form) {
-            if ('quantity' === $form->getName()) {
-                $targetQuantity = $form->getData();
+            if ('quantity' === $form->getName() && $targetQuantity = $form->getData()) {
                 $this->orderItemQuantityModifier->modify($data, $targetQuantity);
 
                 continue;


### PR DESCRIPTION
### Bug / Feature Description
Fix the following error:
```
Expected argument of type "lius\Component\Core\Model\OrderItem::setVariant() must implement interface Sylius\Component\Core\Model\ProductVariantInterface", "NULL" 
```


### Solution / Implementation Description
Add a check for quantity in `OrderItemQuantityDataMapper` but I'm not sure if this is the correct way to fix it.


### JIRA / Asana Ticket URLs
https://reissjira.atlassian.net/browse/RS-2098


### What areas of the site need testing? (think carefully)
 
 

### Have you added PHPSpecs and Behat tests as required? (if not why?)
Will add before merging once I know the proper fix


*Any PRs opened that do not clearly communicate what they are about will be closed - have a nice day.*